### PR TITLE
Issue#1181 fix again for 7.5.0

### DIFF
--- a/fah/ClientConfig.py
+++ b/fah/ClientConfig.py
@@ -432,13 +432,14 @@ class ClientConfig:
         # Selected the first item if nothing is selected
         if selected_row is None:
             selected_row = app.slot_status_list.get_iter_first()
+            app.slot_status_tree.get_selection().select_iter(selected_row)
+            self.select_slot(app)
         if log_filter_row is None:
             log_filter_row = app.slot_status_list.get_iter_first()
 
         # Restore selections
         if selected_row is not None:
             app.slot_status_tree.get_selection().select_iter(selected_row)
-            self.select_slot(app)
         if log_filter_row is not None:
             app.log_slot.set_active_iter(log_filter_row)
 


### PR DESCRIPTION
https://github.com/FoldingAtHome/fah-issues/issues/1181
The additional select call in code must only be called initially when the selected slot changed - not always on update ui. Tested all slot and queue selection variations I could think of and now looks good.