### PR TITLE
[python 3] Replace SocketServer with socketserver

### DIFF
--- a/fah/util/SingleApp.py
+++ b/fah/util/SingleApp.py
@@ -19,7 +19,11 @@
 import sys
 import socket
 import threading
-import SocketServer
+
+try:
+    import socketserver
+except ImportError:
+    import SocketServer as socketserver
 
 import gtk
 
@@ -30,7 +34,7 @@ single_app_port = 32455
 single_app_addr = (single_app_host, single_app_port)
 
 
-class SingleAppRequestHandler(SocketServer.BaseRequestHandler):
+class SingleAppRequestHandler(socketserver.BaseRequestHandler):
     def handle(self):
         cmd = self.request.recv(1024).strip()
 
@@ -44,7 +48,7 @@ class SingleAppRequestHandler(SocketServer.BaseRequestHandler):
 
 
 
-class SingleAppServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+class SingleAppServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     allow_reuse_address = True
 
     def __init__(self):
@@ -54,7 +58,7 @@ class SingleAppServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
         self.ping = threading.Event()
         self.exit_requested = threading.Event()
 
-        SocketServer.TCPServer.__init__(
+        socketserver.TCPServer.__init__(
             self, single_app_addr, SingleAppRequestHandler)
 
         thread = threading.Thread(target = self.serve_forever)


### PR DESCRIPTION
The SocketServer module has been renamed to socketserver in Python 3.