### PR TITLE
Point RPM Requires to Python 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -81,7 +81,7 @@ if env['PLATFORM'] == 'darwin' or env.GetPackageType() == 'rpm':
 
         rpm_license = 'GPL v3+',
         rpm_group = 'Applications/Internet',
-        rpm_requires = 'python, pygtk2',
+        rpm_requires = 'python2, pygtk2',
         rpm_build = 'rpm/build',
         rpm_filelist = 'filelist.txt',
 


### PR DESCRIPTION
This might fix broken `FAHControl` on Fedora (#61)