### PR TITLE
Add Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
We can add [Dependabot](https://dependabot.com/) to automatically create dependency upgrade PRs for us. Note, a maintainer will have to give Dependabot permission to do so for this repo via the [Dependabot](https://dependabot.com/) website.

A couple questions:
- Do we want to add any default reviewers?
- Do we want to automerge patch upgrades?
- Do we want a different frequency? Live? Monthly?

Confirmed the added config is valid via Dependabot's [validator](https://dependabot.com/docs/config-file/validator/):
<img width="1019" alt="Screen Shot 2020-04-28 at 12 16 43" src="https://user-images.githubusercontent.com/1557529/80443456-3cde2c80-894a-11ea-96db-ddb990116816.png">