### PR TITLE
Add entitlements

### DIFF
--- a/fah/FAHControl.py
+++ b/fah/FAHControl.py
@@ -1333,6 +1333,7 @@ class FAHControl(SingleAppServer):
         if not (len(cmd) and len(cmd[0])): cmd = ['FAHViewer']
 
         if sys.platform == 'darwin':
+            if not cmd[0].endswith('.app'): cmd[0] += '.app'
             cmd = ['/usr/bin/open', '-a', cmd[0], '--args'] + cmd[1:]
 
         if fullscreen: cmd.append('--fullscreen')

--- a/osx/entitlements.plist
+++ b/osx/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>
+

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if sys.platform == 'darwin':
             argv_emulation = False,
             includes = 'cairo, pango, pangocairo, atk, gobject, gio',
             iconfile = 'images/FAHControl.icns',
-            resources = ['/opt/local/share/themes'],
+            resources = ['/opt/local/share/themes', 'osx/entitlements.plist'],
             plist = plist,
             )
 


### PR DESCRIPTION
Add entitlements.plist to app bundle for use in codesign later.

Add .app extension to viewer app name used with 'open' command.

It didn't use to matter, but on my machine "open -a FAHViewer" fails, while "open -a FAHViewer.app" works.
Thev 'open' man page examples use the extension.