### PR TITLE
osx updates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,8 +3,8 @@ import os
 env = Environment(ENV = os.environ)
 try:
     env.Tool('config', toolpath = [os.environ.get('CBANG_HOME')])
-except Exception, e:
-    raise Exception, 'CBANG_HOME not set?\n' + str(e)
+except Exception as e:
+    raise Exception('CBANG_HOME not set?\n' + str(e))
 
 env.CBLoadTools('packager run_distutils osx fah-client-version')
 env.CBAddVariables(
@@ -14,7 +14,7 @@ conf = env.CBConfigure()
 # Version
 try:
     version = env.FAHClientVersion()
-except Exception, e:
+except Exception as e:
     print(e)
     version = '0.0.0'
     env.Replace(PACKAGE_VERSION = version)
@@ -30,6 +30,9 @@ target_dir = None
 if env['PLATFORM'] == 'darwin':
     env['RUN_DISTUTILSOPTS'] = 'py2app'
     target_dir = 'dist/FAHControl.app'
+    import shutil
+    # rm old pkg dir so osx fah installer won't bundle an old build
+    shutil.rmtree('build/pkg', True)
 
 elif env['PLATFORM'] == 'win32' or int(env.get('cross_mingw', 0)):
     env['RUN_DISTUTILSOPTS'] = 'build'

--- a/fah/util/__init__.py
+++ b/fah/util/__init__.py
@@ -25,6 +25,13 @@ import sys
 import os
 import gtk
 
+if sys.platform == 'darwin':
+    try:
+        from gtk_osxapplication import *
+    except:
+        from gtkosx_application import gtkosx_application_get_resource_path \
+            as quartz_application_get_resource_path
+
 from SingleApp import *
 from EntryValidator import *
 from PasswordValidator import *
@@ -204,5 +211,9 @@ def get_home_dir():
 
 
 def get_theme_dirs():
+    if sys.platform == 'darwin':
+        resources = quartz_application_get_resource_path()
+        path = os.path.join(resources, 'themes')
+        return [get_home_dir() + '/themes', path]
     return [get_home_dir() + '/themes', gtk.rc_get_theme_dir(),
             '/usr/share/themes']

--- a/osx/entitlements.plist
+++ b/osx/entitlements.plist
@@ -2,8 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 </dict>
 </plist>
-

--- a/osx/scripts/onquit
+++ b/osx/scripts/onquit
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# fahcontrol onquit
+# do that which should not be done while installer is running
+
+# nothing in here is needed if user used the uninstall pkg
+# this is to fix mistakes and fight app relocation
+# fah ~7.5.1 changed bundleid to org.foldinathome.*
+# this caused app relocation for an upgrade install
+
 if [ "$1" != "--delayed-action" ]; then
   "$0" --delayed-action "$@" &
   exit 0
@@ -37,5 +45,13 @@ fi
 if [ -d "$A1" ]; then chmod -R go-w "$A1"; fi
 if [ -d "$A2" ]; then chmod -R go-w "$A2"; fi
 
-# do action
-#"$@"
+A3="/Applications/Folding@home/FAHControl/FAHControl.app"
+F1="/Applications/Folding@home/FAHControl/.DS_Store"
+D1="/Applications/Folding@home/FAHControl"
+[ -d "$A3" ] && [ ! -d "$A2"] && mv "$A3" "$A2" || true
+[ -f "$F1" ] && rm -f "$F1" || true
+[ -d "$D1" ] && rmdir "$D1" || true
+
+# fix incorrect perms, which may persist from old pkg mistake
+D1="/Applications/Folding@home"
+[ -d "$D1" ] && chmod 0755 "$D1" || true

--- a/osx/scripts/postinstall
+++ b/osx/scripts/postinstall
@@ -1,13 +1,6 @@
 #!/bin/bash -e
 
-# fahcontrol postflight/postinstall
-
-D="/Applications/Folding@home"
-if [ -d "$D" ]; then
-    chmod 0755 "$D"
-else
-    mkdir -m 0755 "$D"
-fi
+# fahcontrol postinstall
 
 SCRIPTS="$(dirname "$0")"
 "$SCRIPTS"/onquit

--- a/osx/scripts/preinstall
+++ b/osx/scripts/preinstall
@@ -2,17 +2,11 @@
 
 # fahcontrol preinstall
 
-# delete old app, so system will not relocate if bundle id has changed
-# also delete improperly moved app and cruft
+# pre-delete cruft from old pkg mistakes
+# don't try to mv app here; installer won't like it
+# at some pont, this will not be reasonable to keep doing
 
 A1="/Applications/Folding@home/FAHControl.app"
 A2="/Applications/Folding@home/FAHControl/FAHControl.app"
 
-F1="/Applications/Folding@home/FAHControl/.DS_Store"
-D1="/Applications/Folding@home/FAHControl"
-
-[ -d "$A1" ] && rm -rf "$A1" || true
-[ -d "$A2" ] && rm -rf "$A2" || true
-
-[ -f "$F1" ] && rm -f "$F1" || true
-[ -d "$D1" ] && rmdir "$D1" || true
+[ -d "$A1" ] && [ -d "$A2" ] && rm -rf "$A2" || true

--- a/osx/themes/Default/gtk-2.0-key/gtkrc
+++ b/osx/themes/Default/gtk-2.0-key/gtkrc
@@ -1,0 +1,3 @@
+#
+# Default keybinding set. Empty because it is implemented inline in the code.
+#

--- a/osx/themes/Emacs/gtk-2.0-key/gtkrc
+++ b/osx/themes/Emacs/gtk-2.0-key/gtkrc
@@ -1,0 +1,113 @@
+# GTK - The GIMP Toolkit
+# Copyright (C) 2002 Owen Taylor
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+
+# Modified by the GTK+ Team and others 1997-2000.  See the AUTHORS
+# file for a list of people on the GTK+ Team.  See the ChangeLog
+# files for a list of changes.  These files are distributed with
+# GTK+ at ftp://ftp.gtk.org/pub/gtk/. 
+
+
+#
+# A keybinding set implementing emacs-like keybindings
+#
+
+#
+# Bindings for GtkTextView and GtkEntry
+#
+binding "gtk-emacs-text-entry"
+{
+  bind "<ctrl>b" { "move-cursor" (logical-positions, -1, 0) }
+  bind "<shift><ctrl>b" { "move-cursor" (logical-positions, -1, 1) }
+  bind "<ctrl>f" { "move-cursor" (logical-positions, 1, 0) }
+  bind "<shift><ctrl>f" { "move-cursor" (logical-positions, 1, 1) }
+
+  bind "<alt>b" { "move-cursor" (words, -1, 0) }
+  bind "<shift><alt>b" { "move-cursor" (words, -1, 1) }
+  bind "<alt>f" { "move-cursor" (words, 1, 0) }
+  bind "<shift><alt>f" { "move-cursor" (words, 1, 1) }
+
+  bind "<ctrl>a" { "move-cursor" (paragraph-ends, -1, 0) }
+  bind "<shift><ctrl>a" { "move-cursor" (paragraph-ends, -1, 1) }
+  bind "<ctrl>e" { "move-cursor" (paragraph-ends, 1, 0) }
+  bind "<shift><ctrl>e" { "move-cursor" (paragraph-ends, 1, 1) }
+
+  bind "<ctrl>w" { "cut-clipboard" () }
+  bind "<ctrl>y" { "paste-clipboard" () }
+
+  bind "<ctrl>d" { "delete-from-cursor" (chars, 1) }
+  bind "<alt>d" { "delete-from-cursor" (word-ends, 1) }
+  bind "<ctrl>k" { "delete-from-cursor" (paragraph-ends, 1) }
+  bind "<alt>backslash" { "delete-from-cursor" (whitespace, 1) }
+
+  bind "<alt>space" { "delete-from-cursor" (whitespace, 1)
+                      "insert-at-cursor" (" ") }
+  bind "<alt>KP_Space" { "delete-from-cursor" (whitespace, 1)
+                         "insert-at-cursor" (" ")  }
+
+  #
+  # Some non-Emacs keybindings people are attached to
+  #
+  bind "<ctrl>u" {
+     "move-cursor" (paragraph-ends, -1, 0)
+     "delete-from-cursor" (paragraph-ends, 1)
+  }
+  bind "<ctrl>h" { "delete-from-cursor" (chars, -1) }
+  bind "<ctrl>w" { "delete-from-cursor" (word-ends, -1) }
+}
+
+#
+# Bindings for GtkTextView
+#
+binding "gtk-emacs-text-view"
+{
+  bind "<ctrl>p" { "move-cursor" (display-lines, -1, 0) }
+  bind "<shift><ctrl>p" { "move-cursor" (display-lines, -1, 1) }
+  bind "<ctrl>n" { "move-cursor" (display-lines, 1, 0) }
+  bind "<shift><ctrl>n" { "move-cursor" (display-lines, 1, 1) }
+
+  bind "<ctrl>space" { "set-anchor" () }
+  bind "<ctrl>KP_Space" { "set-anchor" () }
+}
+
+#
+# Bindings for GtkTreeView
+#
+binding "gtk-emacs-tree-view"
+{
+  bind "<ctrl>s" { "start-interactive-search" () }
+  bind "<ctrl>f" { "move-cursor" (logical-positions, 1) }
+  bind "<ctrl>b" { "move-cursor" (logical-positions, -1) }
+}
+
+#
+# Bindings for menus
+#
+binding "gtk-emacs-menu"
+{
+  bind "<ctrl>n" { "move-current" (next) }
+  bind "<ctrl>p" { "move-current" (prev) }
+  bind "<ctrl>f" { "move-current" (child) }
+  bind "<ctrl>b" { "move-current" (parent) }
+}
+
+class "GtkEntry" binding "gtk-emacs-text-entry"
+class "GtkTextView" binding "gtk-emacs-text-entry"
+class "GtkTextView" binding "gtk-emacs-text-view"
+class "GtkTreeView" binding "gtk-emacs-tree-view"
+class "GtkMenuShell" binding "gtk-emacs-menu"

--- a/osx/themes/Mac/gtk-2.0-key/gtkrc
+++ b/osx/themes/Mac/gtk-2.0-key/gtkrc
@@ -1,0 +1,157 @@
+gtk-enable-mnemonics = 0
+
+binding "gtk-mac-alt-arrows"
+{
+  bind "<alt>Right"           { "move-cursor" (words, 1, 0) }
+  bind "<alt>KP_Right"        { "move-cursor" (words, 1, 0) }
+  bind "<alt>Left"            { "move-cursor" (words, -1, 0) }
+  bind "<alt>KP_Left"         { "move-cursor" (words, -1, 0) }
+  bind "<shift><alt>Right"    { "move-cursor" (words, 1, 1) }
+  bind "<shift><alt>KP_Right" { "move-cursor" (words, 1, 1) }
+  bind "<shift><alt>Left"     { "move-cursor" (words, -1, 1) }
+  bind "<shift><alt>KP_Left"  { "move-cursor" (words, -1, 1) }
+}
+
+class "GtkTextView" binding "gtk-mac-alt-arrows"
+class "GtkLabel" binding "gtk-mac-alt-arrows"
+class "GtkEntry" binding "gtk-mac-alt-arrows"
+
+
+binding "gtk-mac-alt-delete"
+{
+  bind "<alt>Delete" { "delete-from-cursor" (word-ends, 1) }
+  bind "<alt>KP_Delete" { "delete-from-cursor" (word-ends, 1) }
+  bind "<alt>BackSpace" { "delete-from-cursor" (word-ends, -1) }
+}
+
+class "GtkTextView" binding "gtk-mac-alt-delete"
+class "GtkEntry" binding "gtk-mac-alt-delete"
+
+
+binding "gtk-mac-cmd-c"
+{
+  bind "<meta>x" { "cut-clipboard" () }
+  bind "<meta>c" { "copy-clipboard" () }
+  bind "<meta>v" { "paste-clipboard" () }
+  unbind "<ctrl>x"
+  unbind "<ctrl>c"
+  unbind "<ctrl>v"
+}
+
+class "GtkTextView" binding "gtk-mac-cmd-c"
+class "GtkEntry" binding "gtk-mac-cmd-c"
+
+
+binding "gtk-mac-text-view"
+{
+  bind "<shift><meta>a" { "select-all" (0) }
+  bind "<meta>a" { "select-all" (1) }
+  unbind "<shift><ctrl>a"
+  unbind "<ctrl>a"
+}
+
+class "GtkTextView" binding "gtk-mac-text-view"
+
+
+binding "gtk-mac-label"
+{
+  bind "<meta>a" {
+    "move-cursor" (paragraph-ends, -1, 0)
+    "move-cursor" (paragraph-ends, 1, 1)
+  }
+  bind "<shift><meta>a" { "move-cursor" (paragraph-ends, 0, 0) }
+  bind "<meta>c" { "copy-clipboard" () }
+  unbind "<ctrl>a"
+  unbind "<shift><ctrl>a"
+  unbind "<ctrl>c"
+}
+
+class "GtkLabel" binding "gtk-mac-label"
+
+
+binding "gtk-mac-entry"
+{
+  bind "<meta>a" {
+    "move-cursor" (buffer-ends, -1, 0)
+    "move-cursor" (buffer-ends, 1, 1)
+  }
+  bind "<shift><meta>a" { "move-cursor" (visual-positions, 0, 0) }
+  unbind "<ctrl>a"
+  unbind "<shift><ctrl>a"
+}
+
+class "GtkEntry" binding "gtk-mac-entry"
+
+
+binding "gtk-mac-cmd-arrows"
+{
+  bind "<meta>Left" { "move-cursor" (paragraph-ends, -1, 0) }
+  bind "<meta>KP_Left" { "move-cursor" (paragraph-ends, -1, 0) }
+  bind "<shift><meta>Left" { "move-cursor" (paragraph-ends, -1, 1) }
+  bind "<shift><meta>KP_Left" { "move-cursor" (paragraph-ends, -1, 1) }
+  bind "<meta>Right" { "move-cursor" (paragraph-ends, 1, 0) }
+  bind "<meta>KP_Right" { "move-cursor" (paragraph-ends, 1, 0) }
+  bind "<shift><meta>Right" { "move-cursor" (paragraph-ends, 1, 1) }
+  bind "<shift><meta>KP_Right" { "move-cursor" (paragraph-ends, 1, 1) }
+}
+
+class "GtkTextView" binding "gtk-mac-cmd-arrows"
+class "GtkLabel" binding "gtk-mac-cmd-arrows"
+class "GtkEntry" binding "gtk-mac-cmd-arrows"
+
+
+binding "gtk-mac-emacs-like"
+{
+  bind "<ctrl>a" { "move-cursor" (paragraph-ends, -1, 0) }
+  bind "<shift><ctrl>a" { "move-cursor" (paragraph-ends, -1, 1) }
+  bind "<ctrl>e" { "move-cursor" (paragraph-ends, 1, 0) }
+  bind "<shift><ctrl>e" { "move-cursor" (paragraph-ends, 1, 1) }
+
+  bind "<ctrl>b" { "move-cursor" (logical-positions, -1, 0) }
+  bind "<shift><ctrl>b" { "move-cursor" (logical-positions, -1, 1) }
+  bind "<ctrl>f" { "move-cursor" (logical-positions, 1, 0) }
+  bind "<shift><ctrl>f" { "move-cursor" (logical-positions, 1, 1) }
+}
+
+class "GtkTextView" binding "gtk-mac-emacs-like"
+class "GtkLabel" binding "gtk-mac-emacs-like"
+class "GtkEntry" binding "gtk-mac-emacs-like"
+
+
+binding "gtk-mac-file-chooser"
+{
+  bind "<meta>v" { "location-popup-on-paste" () }
+  unbind "<ctrl>v"
+
+  bind "<meta><shift>G" { "location-popup" () }
+  bind "<meta><shift>H" { "home-folder" () }
+  bind "<meta>Up" { "up-folder" () }
+}
+
+class "GtkFileChooserDefault" binding "gtk-mac-file-chooser"
+
+
+binding "gtk-mac-tree-view"
+{
+  bind "<meta>a" { "select-all" () }
+  bind "<shift><meta>a" { "unselect-all" () }
+  bind "<meta>f" { "start-interactive-search" () }
+  bind "<meta>F" { "start-interactive-search" () }
+  unbind "<ctrl>a"
+  unbind "<shift><ctrl>a"
+  unbind "<ctrl>f"
+  unbind "<ctrl>F"
+}
+
+class "GtkTreeView" binding "gtk-mac-tree-view"
+
+
+binding "gtk-mac-icon-view"
+{
+  bind "<meta>a" { "select-all" () }
+  bind "<shift><meta>a" { "unselect-all" () }
+  unbind "<ctrl>a"
+  unbind "<shift><ctrl>a"
+}
+
+class "GtkIconView" binding "gtk-mac-icon-view"

--- a/osx/themes/Raleigh/gtk-2.0/gtkrc
+++ b/osx/themes/Raleigh/gtk-2.0/gtkrc
@@ -1,0 +1,3 @@
+#
+# This theme is the default theme if no other theme is selected.
+#

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if sys.platform == 'darwin':
             argv_emulation = False,
             includes = 'cairo, pango, pangocairo, atk, gobject, gio',
             iconfile = 'images/FAHControl.icns',
-            resources = ['/opt/local/share/themes', 'osx/entitlements.plist'],
+            resources = ['osx/themes', 'osx/entitlements.plist'],
             plist = plist,
             )
 


### PR DESCRIPTION
Delete build/pkg before building.
Make build files python3-ready.
Update osx installer scripts.
Add osx/themes directory with gtk2 themes.
Add sandbox entitlements.
Do not access themes dirs not allowed by sandbox.
Disable sandbox for now, as it interferes with passing args to FAHViewer.
Probably need app groups entitlement and drop an args.json file in group container.